### PR TITLE
Fix: Add layout in nosotros and container text

### DIFF
--- a/src/Components/About/AboutPrincipal.js
+++ b/src/Components/About/AboutPrincipal.js
@@ -3,6 +3,7 @@ import SpinnerComponent from '../UI/spinner/SpinnerComponent'
 import ErrorAlert from '../UI/Alerts/ErrorAlert'
 import AboutUs from './AboutUs'
 import './stylesAboutUs.css'
+import LayoutPublic from '../Layout/LayoutPublic'
 
 export default function AboutPrincipal() {
 	const [loading, setLoading] = useState(false)
@@ -37,8 +38,10 @@ export default function AboutPrincipal() {
 		return <ErrorAlert />
 	}
 	return (
-		<main className="aboutPrincipal-container">
-			<AboutUs text={principalText} />
-		</main>
+		<LayoutPublic>
+			<main className="aboutPrincipal-container">
+				<AboutUs text={principalText} />
+			</main>
+		</LayoutPublic>
 	)
 }

--- a/src/Components/About/AboutUs.js
+++ b/src/Components/About/AboutUs.js
@@ -16,7 +16,7 @@ export default function AboutUs({ text }) {
 		<div className="aboutUs-container">
 			<TitleComponent text="Nosotros" />
 			<h3 className="subtitle">Sobre nosotros</h3>
-			<p>{text}</p>
+			<p className="about-text">{text}</p>
 		</div>
 	)
 }

--- a/src/Components/About/stylesAboutUs.css
+++ b/src/Components/About/stylesAboutUs.css
@@ -1,4 +1,5 @@
 .aboutPrincipal-container {
+	margin-top: 110px;
 	display: flex;
 	align-items: center;
 	flex-direction: column;
@@ -16,8 +17,25 @@
 .aboutUs-container p {
 	text-align: justify;
 }
+
 .spinner-container {
 	display: flex;
 	justify-content: center;
 	align-items: center;
+}
+
+.about-text {
+	max-width: 60%;
+}
+
+@media screen and (max-width: 1024px) {
+	.about-text {
+		max-width: 75%;
+	}
+}
+
+@media screen and (max-width: 768px) {
+	.about-text {
+		max-width: 90%;
+	}
 }


### PR DESCRIPTION
Acciones realizadas:
- Se añadió el LayoutPublic en el componente de Nosotros.
- Se agregó una clase a la etiqueta P de Nosotros.
- Se agregó un margen de 110px para el contenedor de nosotros, porque quedaba debajo del header.
- Se estableció un max-width al texto de nosotros porque quedaba muy largo.

Preview:
![image](https://user-images.githubusercontent.com/49167174/159515122-e7dc0679-a116-4eb5-bd2e-aafa05ce2a2a.png)
![image](https://user-images.githubusercontent.com/49167174/159515209-b88fcec7-4ae3-4e38-b4be-e8b0b56072cf.png)
